### PR TITLE
update of customisation function `customizeHLTFor2022L1TMenu`

### DIFF
--- a/HLTrigger/Configuration/python/README.md
+++ b/HLTrigger/Configuration/python/README.md
@@ -1,10 +1,10 @@
-### HLT customization functions for Run-3
+### HLT customization functions for 2023 Run-3 studies
 
 ```
-cmsrel CMSSW_13_0_0_pre4
-cd CMSSW_13_0_0_pre4/src
+cmsrel CMSSW_13_0_0
+cd CMSSW_13_0_0/src
 cmsenv
-git cms-merge-topic  silviodonato:customizeHLTFor2023
+git cms-merge-topic silviodonato:customizeHLTFor2023
 scram b -j4
 hltGetConfiguration (....) > hlt.py 
 ```
@@ -26,9 +26,9 @@ or you can use it in cmsDriver:
 cmsDriver.py step2 (...) --customise HLTrigger/Configuration/customizeHLTFor2023.customizeHLTFor2023
 ```
 
-Examples:
+Example 1:
 ```
-hltGetConfiguration /dev/CMSSW_13_0_0/GRun \
+hltGetConfiguration /dev/CMSSW_13_0_0/GRun/V24 \
    --globaltag 126X_dataRun3_HLT_v1 \
    --data \
    --unprescale \
@@ -42,19 +42,39 @@ hltGetConfiguration /dev/CMSSW_13_0_0/GRun \
 cmsRun hltData.py >& log &
 ```
 
-or (example from step2 of `runTheMatrix.py -l 140.003 -n --extended`)
-
+Example 2: (taken from step2 of `runTheMatrix.py -l 140.003 -n --extended`)
 ```
-cmsDriver.py step2  --process reHLT -s L1REPACK:Full,HLT:@relval2022 --conditions auto:run3_hlt_relval --data  --eventcontent FEVTDEBUGHLT --datatier FEVTDEBUGHLT --era Run3 -n 10 --filein=/store/data/Run2022G/EphemeralHLTPhysics3/RAW/v1/000/362/720/00000/850a6b3c-6eef-424c-9dad-da1e678188f3.root  --customise HLTrigger/Configuration/customizeHLTFor2023.customizeHCALFor2023
+cmsDriver.py step2 --process reHLT -s L1REPACK:Full,HLT:GRun --conditions auto:run3_hlt_relval --data --eventcontent FEVTDEBUGHLT --datatier FEVTDEBUGHLT --era Run3 -n 10 --filein=/store/data/Run2022G/EphemeralHLTPhysics3/RAW/v1/000/362/720/00000/850a6b3c-6eef-424c-9dad-da1e678188f3.root --customise HLTrigger/Configuration/customizeHLTFor2023.customizeHCALFor2023
 
 cmsRun step2_L1REPACK_HLT.py >& log &
 ```
 
-### Customization function to run the latest HLT menu on 2022 data collected with L1Menu_Collisions2022_v1_5_0
+Example-1 extracts from ConfDB the menu `GRun/V24`, which is the last version of the GRun menu compatible with the last L1T menu of 2022, i.e. [`L1Menu_Collisions2022_v1_4_0`](https://htmlpreview.github.io/?https://github.com/cms-l1-dpg/L1MenuRun3/blob/57fcce7ecf26366084813755f769f47be58bbf5f/development/L1Menu_Collisions2022_v1_4_0/L1Menu_Collisions2022_v1_4_0.html).
 
-If you want to run on 2022 data using the old L1Menu_Collisions2022_v1_5_0, you can get the latest HLT GRun menu compatible using 
+Example-2 uses the version of the GRun menu available in the CMSSW release; for `CMSSW_13_0_0`, this corresponds to `GRun/V14`.
+
+### Customization function to run the latest HLT menu on 2022 data collected with L1Menu_Collisions2022_v1_4_0
+
+The latest version of the GRun menu in ConfDB is compatible with the first L1T menu of 2023, i.e. [`L1Menu_Collisions2023_v1_0_0`](https://htmlpreview.github.io/?https://github.com/cms-l1-dpg/L1MenuRun3/blob/57fcce7ecf26366084813755f769f47be58bbf5f/development/L1Menu_Collisions2023_v1_0_0/L1Menu_Collisions2023_v1_0_0.html).
+
+If you want to run on 2022 data using the old [`L1Menu_Collisions2022_v1_4_0`](https://htmlpreview.github.io/?https://github.com/cms-l1-dpg/L1MenuRun3/blob/57fcce7ecf26366084813755f769f47be58bbf5f/development/L1Menu_Collisions2022_v1_4_0/L1Menu_Collisions2022_v1_4_0.html), you can customise the latest HLT GRun menu to make it compatible with the last L1T menu of 2022 using
 ```
---customise HLTrigger/Configuration/customizeHLTFor2023.customiseHLTfor2022L1TMenu
+--customise HLTrigger/Configuration/customizeHLTFor2023.customizeHLTFor2022L1TMenu
+```
+Example:
+```
+hltGetConfiguration /dev/CMSSW_13_0_0/GRun \
+   --globaltag 126X_dataRun3_HLT_v1 \
+   --data \
+   --unprescale \
+   --output minimal \
+   --max-events 100 \
+   --customise \
+HLTrigger/Configuration/customizeHLTFor2023.customizeHLTFor2023,\
+HLTrigger/Configuration/customizeHLTFor2023.customizeHLTFor2022L1TMenu \
+   --eras Run3 \
+   --input /store/data/Run2022G/EphemeralHLTPhysics3/RAW/v1/000/362/720/00000/850a6b3c-6eef-424c-9dad-da1e678188f3.root \
+   > hltData.py
 ```
 
 ### Note
@@ -63,8 +83,8 @@ You can use separately the two functions `customizeHLTFor2023.customizePFHadronC
 
 ### References
 
-slide 12 from Salavat's talk https://indico.cern.ch/event/1237252/contributions/5204534 
+ - Slide 12 from Salavat's talk: [[Indico link]](https://indico.cern.ch/event/1237252/contributions/5204534)
 
-(PPD coordination meeting: https://indico.cern.ch/event/1251668)
+ - PPD coordination meeting: [[Indico link]](https://indico.cern.ch/event/1251668)
 
-Changgi's slides at JetMET trigger ( https://indico.cern.ch/event/1258851/ )
+ - Changgi's slides at JetMET trigger: [[Indico link]](https://indico.cern.ch/event/1258851/)

--- a/HLTrigger/Configuration/python/customizeHLTFor2023.py
+++ b/HLTrigger/Configuration/python/customizeHLTFor2023.py
@@ -71,7 +71,7 @@ def customizeHLTFor2023(process):
     process = customizeHCALFor2023(process)
     return process
 
-def customiseHLTfor2022L1TMenu(process):
+def customizeHLTFor2022L1TMenu(process):
 
     dictL1TSeeds2022 = {
 
@@ -98,6 +98,12 @@ def customiseHLTfor2022L1TMenu(process):
 
       # HIG (VBF HTauTau)
       'hltL1VBFDiJetIsoTau': 'L1_DoubleJet35_Mass_Min450_IsoTau45er2p1_RmOvlp_dR0p5',
+
+      # BPH (BsMuMu)
+      'hltL1sDoubleMuForBs': 'L1_DoubleMu3er2p0_SQ_OS_dR_Max1p4 OR L1_DoubleMu0er2p0_SQ_OS_dEta_Max1p6 OR L1_DoubleMu0er1p4_OQ_OS_dEta_Max1p6 OR L1_DoubleMu0er2p0_SQ_OS_dEta_Max1p5 OR L1_DoubleMu0er1p4_SQ_OS_dR_Max1p4 OR L1_DoubleMu0er1p5_SQ_OS_dR_Max1p4 OR L1_DoubleMu4p5_SQ_OS_dR_Max1p2 OR L1_DoubleMu4_SQ_OS_dR_Max1p2',
+      'hltL1sDoubleMuForBsToMMG': 'L1_DoubleMu3er2p0_SQ_OS_dR_Max1p4 OR L1_DoubleMu0er2p0_SQ_OS_dEta_Max1p6 OR L1_DoubleMu0er2p0_SQ_OS_dEta_Max1p5 OR L1_DoubleMu0er1p4_SQ_OS_dR_Max1p4 OR L1_DoubleMu0er1p5_SQ_OS_dR_Max1p4 OR L1_DoubleMu4p5_SQ_OS_dR_Max1p2 OR L1_DoubleMu4_SQ_OS_dR_Max1p2',
+      'hltL1sDoubleMuForLowMassDisplaced': 'L1_DoubleMu3er2p0_SQ_OS_dR_Max1p4 OR L1_DoubleMu0er2p0_SQ_OS_dEta_Max1p6 OR L1_DoubleMu0er1p4_OQ_OS_dEta_Max1p6 OR L1_DoubleMu0er2p0_SQ_OS_dEta_Max1p5 OR L1_DoubleMu0er1p4_SQ_OS_dR_Max1p4 OR L1_DoubleMu0er1p5_SQ_OS_dR_Max1p4 OR L1_DoubleMu4p5_SQ_OS_dR_Max1p2 OR L1_DoubleMu4_SQ_OS_dR_Max1p2',
+      'hltL1sDoubleMuForLowMassInclusive': 'L1_DoubleMu3er2p0_SQ_OS_dR_Max1p4 OR L1_DoubleMu0er2p0_SQ_OS_dEta_Max1p6 OR L1_DoubleMu0er1p4_OQ_OS_dEta_Max1p6 OR L1_DoubleMu0er2p0_SQ_OS_dEta_Max1p5 OR L1_DoubleMu0er1p4_SQ_OS_dR_Max1p4 OR L1_DoubleMu0er1p5_SQ_OS_dR_Max1p4 OR L1_DoubleMu4p5_SQ_OS_dR_Max1p2 OR L1_DoubleMu4_SQ_OS_dR_Max1p2',
     }
 
     for modName,oldSeed in dictL1TSeeds2022.items():


### PR DESCRIPTION
This PR updates the customisation function to use the 2022 L1T menu with the latest HLT GRun menu, in order to comply with upcoming changes to the L1T seeds of the dimuon parking triggers ([CMSHLT-2688](https://its.cern.ch/jira/browse/CMSHLT-2688)).

The function is renamed, to be consistent with other functions in the same file.

The `README` is updated accordingly, and some info is added.
