### PR TITLE
modify all instances of `CaloTowersCreator` in `customizeHCALinCaloJets`

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTFor2023.py
+++ b/HLTrigger/Configuration/python/customizeHLTFor2023.py
@@ -52,10 +52,10 @@ def customizeHCAL(process, HCAL_PFclusters, HCAL_PFrechits):
     return process
 
 def customizeHCALinCaloJets(process, HCAL_PFrechits):
-    if hasattr(process, "hltTowerMakerForAll"):
-        process.hltTowerMakerForAll.HBThreshold1 = HCAL_PFrechits[0]
-        process.hltTowerMakerForAll.HBThreshold2 = HCAL_PFrechits[1]
-        process.hltTowerMakerForAll.HBThreshold  = HCAL_PFrechits[2]
+    for mod in producers_by_type(process, 'CaloTowersCreator'):
+        mod.HBThreshold1 = HCAL_PFrechits[0]
+        mod.HBThreshold2 = HCAL_PFrechits[1]
+        mod.HBThreshold  = HCAL_PFrechits[2]
     return process
 
 def customizeHCALinCaloJetsFor2023(process):


### PR DESCRIPTION
The current version of `customizeHCALinCaloJets` considers only the module `hltTowerMakerForAll`, but I don't see a good reason why other instances of `CaloTowersCreator` should continue to use the older thresholds.

@silviodonato