### PR TITLE
add `customizeHLTFor2023L1TMenu_v1_0_0` function

### DIFF
--- a/HLTrigger/Configuration/python/README.md
+++ b/HLTrigger/Configuration/python/README.md
@@ -9,8 +9,8 @@ All previous JEC and PF hadron calibration are wrong because of the ECAL bug in 
 To get the fixed ECAL tag in MC please use 126X_mcRun3_2023_forPU65_v4. For data, please use the usual global tag.
 
 ```
-cmsrel CMSSW_13_0_0
-cd CMSSW_13_0_0/src
+cmsrel CMSSW_13_0_5_patch1
+cd CMSSW_13_0_5_patch1/src
 cmsenv
 git cms-merge-topic silviodonato:customizeHLTFor2023
 scram b -j4
@@ -37,7 +37,7 @@ cmsDriver.py step2 (...) --customise HLTrigger/Configuration/customizeHLTFor2023
 Example 1:
 ```
 hltGetConfiguration /dev/CMSSW_13_0_0/GRun/V24 \
-   --globaltag 126X_dataRun3_HLT_v1 \
+   --globaltag 130X_dataRun3_HLT_v2 \
    --data \
    --unprescale \
    --output minimal \
@@ -57,7 +57,8 @@ cmsDriver.py step2 --process reHLT -s L1REPACK:Full,HLT:GRun --conditions auto:r
 cmsRun step2_L1REPACK_HLT.py >& log &
 ```
 
-Example-1 extracts from ConfDB the menu `GRun/V24`, which is the last version of the GRun menu compatible with the last L1T menu of 2022, i.e. [`L1Menu_Collisions2022_v1_4_0`](https://htmlpreview.github.io/?https://github.com/cms-l1-dpg/L1MenuRun3/blob/57fcce7ecf26366084813755f769f47be58bbf5f/development/L1Menu_Collisions2022_v1_4_0/L1Menu_Collisions2022_v1_4_0.html).
+Example-1 extracts from ConfDB the menu `GRun/V24`, which is the last version of the GRun menu compatible with the last L1T menu of 2022, i.e.
+[`L1Menu_Collisions2022_v1_4_0`](https://htmlpreview.github.io/?https://github.com/cms-l1-dpg/L1MenuRun3/blob/57fcce7ecf26366084813755f769f47be58bbf5f/development/L1Menu_Collisions2022_v1_4_0/L1Menu_Collisions2022_v1_4_0.html).
 
 Example-2 uses the version of the GRun menu available in the CMSSW release; for `CMSSW_13_0_0`, this corresponds to `GRun/V14`.
 
@@ -82,16 +83,41 @@ customizeJECFor2023_noAK8CaloHLT (OBSOLETE):
 
 ### Customization function to run the latest HLT menu on 2022 data collected with L1Menu_Collisions2022_v1_4_0
 
-The latest version of the GRun menu in ConfDB is compatible with the first L1T menu of 2023, i.e. [`L1Menu_Collisions2023_v1_0_0`](https://htmlpreview.github.io/?https://github.com/cms-l1-dpg/L1MenuRun3/blob/57fcce7ecf26366084813755f769f47be58bbf5f/development/L1Menu_Collisions2023_v1_0_0/L1Menu_Collisions2023_v1_0_0.html).
+The latest version of the GRun menu in ConfDB is compatible with the latest L1T menu of 2023, i.e.
+[`L1Menu_Collisions2023_v1_1_0`](https://htmlpreview.github.io/?https://github.com/cms-l1-dpg/L1MenuRun3/blob/master/development/L1Menu_Collisions2023_v1_1_0/L1Menu_Collisions2023_v1_1_0.html).
 
-If you want to run on 2022 data using the old [`L1Menu_Collisions2022_v1_4_0`](https://htmlpreview.github.io/?https://github.com/cms-l1-dpg/L1MenuRun3/blob/57fcce7ecf26366084813755f769f47be58bbf5f/development/L1Menu_Collisions2022_v1_4_0/L1Menu_Collisions2022_v1_4_0.html), you can customise the latest HLT GRun menu to make it compatible with the last L1T menu of 2022 using
+In order to modify the latest GRun menu to make it compatible with the first L1T menu of 2023, i.e.
+[`L1Menu_Collisions2023_v1_0_0`](https://htmlpreview.github.io/?https://github.com/cms-l1-dpg/L1MenuRun3/blob/master/development/L1Menu_Collisions2023_v1_0_0/L1Menu_Collisions2023_v1_0_0.html),
+the following customisation can be used
+```
+--customise HLTrigger/Configuration/customizeHLTFor2023.customizeHLTFor2023L1TMenu_v1_0_0
+```
+Example:
+```
+hltGetConfiguration /dev/CMSSW_13_0_0/GRun \
+   --globaltag 130X_dataRun3_HLT_v2 \
+   --data \
+   --unprescale \
+   --output minimal \
+   --max-events 100 \
+   --customise \
+HLTrigger/Configuration/customizeHLTFor2023.customizeHLTFor2023_v5_fromFile,\
+HLTrigger/Configuration/customizeHLTFor2023.customizeHLTFor2023L1TMenu_v1_0_0 \
+   --eras Run3 \
+   --input [input ROOT file] \
+   > hltData.py
+```
+
+Similarly, if you want to run on 2022 data using the old
+[`L1Menu_Collisions2022_v1_4_0`](https://htmlpreview.github.io/?https://github.com/cms-l1-dpg/L1MenuRun3/blob/57fcce7ecf26366084813755f769f47be58bbf5f/development/L1Menu_Collisions2022_v1_4_0/L1Menu_Collisions2022_v1_4_0.html),
+you can customise the latest HLT GRun menu to make it compatible with the last L1T menu of 2022 using
 ```
 --customise HLTrigger/Configuration/customizeHLTFor2023.customizeHLTFor2022L1TMenu
 ```
 Example:
 ```
 hltGetConfiguration /dev/CMSSW_13_0_0/GRun \
-   --globaltag 126X_dataRun3_HLT_v1 \
+   --globaltag 130X_dataRun3_HLT_v2 \
    --data \
    --unprescale \
    --output minimal \
@@ -103,6 +129,8 @@ HLTrigger/Configuration/customizeHLTFor2023.customizeHLTFor2022L1TMenu \
    --input /store/data/Run2022G/EphemeralHLTPhysics3/RAW/v1/000/362/720/00000/850a6b3c-6eef-424c-9dad-da1e678188f3.root \
    > hltData.py
 ```
+
+
 
 ### Note
 

--- a/HLTrigger/Configuration/python/customizeHLTFor2023.py
+++ b/HLTrigger/Configuration/python/customizeHLTFor2023.py
@@ -448,46 +448,64 @@ def customizeHLTFor2023_v5_fromFile(process):
     return process
 
 
-def customizeHLTFor2022L1TMenu(process):
+def _updateL1TSeedModules(process, l1tMenu):
 
-    dictL1TSeeds2022 = {
-
-      # BPH (Tau3Mu)
-      'hltL1sTripleMuControl': 'L1_TripleMu_5SQ_3SQ_0OQ',
-      'hltL1sDoubleMu0er2p0SQOSdEtaMax1p6orTripleMu21p50': 'L1_DoubleMu0er2p0_SQ_OS_dEta_Max1p6 OR L1_DoubleMu0er2p0_SQ_OS_dEta_Max1p5 OR L1_DoubleMu0er1p5_SQ_OS_dR_Max1p4 OR L1_DoubleMu0er1p4_SQ_OS_dR_Max1p4 OR L1_TripleMu_5SQ_3SQ_0_DoubleMu_5_3_SQ_OS_Mass_Max9 OR L1_TripleMu_5SQ_3SQ_0OQ_DoubleMu_5_3_SQ_OS_Mass_Max9 OR L1_TripleMu_2SQ_1p5SQ_0OQ_Mass_Max12 OR L1_DoubleMu4_SQ_OS_dR_Max1p2 OR L1_DoubleMu4p5_SQ_OS_dR_Max1p2',
-
-      # BTV
-      'hltL1sDiJet16er2p5Mu3dRMax0p4': 'L1_Mu3_Jet16er2p5_dR_Max0p4',
-      'hltL1sDiJet35er2p5Mu3dRMax0p4': 'L1_Mu3_Jet35er2p5_dR_Max0p4',
-      'hltL1sDiJet60er2p5Mu3dRMax0p4': 'L1_Mu3_Jet60er2p5_dR_Max0p4',
-      'hltL1sDiJet80er2p5Mu3dRMax0p4': 'L1_Mu3_Jet80er2p5_dR_Max0p4',
-      'hltL1sDiJet120er2p5Mu3dRMax0p8': 'L1_Mu3_Jet120er2p5_dR_Max0p8',
-
-      # JME
-      'hltL1sSingleJet35Fwd': 'L1_SingleJet35_FWD3p0',
-      'hltL1sSingleJet35OrZeroBias': 'L1_SingleJet35 OR L1_SingleJet35_FWD3p0 OR L1_ZeroBias',
-      'hltL1sSingleJet60Fwd': 'L1_SingleJet60_FWD3p0',
-      'hltL1sSingleJet60Or60Fwd': 'L1_SingleJet60 OR L1_SingleJet60_FWD3p0',
-      'hltL1sSingleJet90Fwd': 'L1_SingleJet90_FWD3p0',
-      'hltL1sV0SingleJet60Or60Fwd': 'L1_SingleJet60 OR L1_SingleJet60_FWD3p0 OR L1_SingleJet90 OR L1_SingleJet90_FWD3p0',
-      'hltL1sSingleJet120Fwd': 'L1_SingleJet120_FWD3p0',
-      'hltL1sSingleJet120Or120Fwd': 'L1_SingleJet120 OR L1_SingleJet120_FWD3p0',
-
-      # HIG (VBF HTauTau)
-      'hltL1VBFDiJetIsoTau': 'L1_DoubleJet35_Mass_Min450_IsoTau45er2p1_RmOvlp_dR0p5',
-
-      # BPH (BsMuMu)
-      'hltL1sDoubleMuForBs': 'L1_DoubleMu3er2p0_SQ_OS_dR_Max1p4 OR L1_DoubleMu0er2p0_SQ_OS_dEta_Max1p6 OR L1_DoubleMu0er1p4_OQ_OS_dEta_Max1p6 OR L1_DoubleMu0er2p0_SQ_OS_dEta_Max1p5 OR L1_DoubleMu0er1p4_SQ_OS_dR_Max1p4 OR L1_DoubleMu0er1p5_SQ_OS_dR_Max1p4 OR L1_DoubleMu4p5_SQ_OS_dR_Max1p2 OR L1_DoubleMu4_SQ_OS_dR_Max1p2',
-      'hltL1sDoubleMuForBsToMMG': 'L1_DoubleMu3er2p0_SQ_OS_dR_Max1p4 OR L1_DoubleMu0er2p0_SQ_OS_dEta_Max1p6 OR L1_DoubleMu0er2p0_SQ_OS_dEta_Max1p5 OR L1_DoubleMu0er1p4_SQ_OS_dR_Max1p4 OR L1_DoubleMu0er1p5_SQ_OS_dR_Max1p4 OR L1_DoubleMu4p5_SQ_OS_dR_Max1p2 OR L1_DoubleMu4_SQ_OS_dR_Max1p2',
-      'hltL1sDoubleMuForLowMassDisplaced': 'L1_DoubleMu3er2p0_SQ_OS_dR_Max1p4 OR L1_DoubleMu0er2p0_SQ_OS_dEta_Max1p6 OR L1_DoubleMu0er1p4_OQ_OS_dEta_Max1p6 OR L1_DoubleMu0er2p0_SQ_OS_dEta_Max1p5 OR L1_DoubleMu0er1p4_SQ_OS_dR_Max1p4 OR L1_DoubleMu0er1p5_SQ_OS_dR_Max1p4 OR L1_DoubleMu4p5_SQ_OS_dR_Max1p2 OR L1_DoubleMu4_SQ_OS_dR_Max1p2',
-      'hltL1sDoubleMuForLowMassInclusive': 'L1_DoubleMu3er2p0_SQ_OS_dR_Max1p4 OR L1_DoubleMu0er2p0_SQ_OS_dEta_Max1p6 OR L1_DoubleMu0er1p4_OQ_OS_dEta_Max1p6 OR L1_DoubleMu0er2p0_SQ_OS_dEta_Max1p5 OR L1_DoubleMu0er1p4_SQ_OS_dR_Max1p4 OR L1_DoubleMu0er1p5_SQ_OS_dR_Max1p4 OR L1_DoubleMu4p5_SQ_OS_dR_Max1p2 OR L1_DoubleMu4_SQ_OS_dR_Max1p2',
-
-      # SMP (W->3pi)
-      'hltL1sDoubleTauBigORWithLowMass': 'L1_DoubleIsoTau34er2p1 OR L1_DoubleIsoTau36er2p1 OR L1_DoubleTau70er2p1 OR L1_DoubleIsoTau28er2p1_Mass_Max80 OR L1_DoubleIsoTau30er2p1_Mass_Max80',
+    dictL1TSeeds = {
+      # VBF Parking (exclusive seeds)
+      'hltL1DiJetVBFdoubleJet': 'L1_DoubleJet_110_35_DoubleJet35_Mass_Min620',
+      'hltL1DiJetVBFMET': 'L1_DoubleJet_110_35_DoubleJet35_Mass_Min620',
+      'hltL1DoubleJet8030MassMin500Mu3': 'L1_DoubleJet_110_35_DoubleJet35_Mass_Min620',
+      'hltL1VBFIsoEG': 'L1_DoubleJet_110_35_DoubleJet35_Mass_Min620',
     }
 
-    for modName,oldSeed in dictL1TSeeds2022.items():
+    if l1tMenu == '2022_v1_4_0':
+
+        dictL1TSeeds.update({
+          # BPH (Tau3Mu)
+          'hltL1sTripleMuControl': 'L1_TripleMu_5SQ_3SQ_0OQ',
+          'hltL1sDoubleMu0er2p0SQOSdEtaMax1p6orTripleMu21p50': 'L1_DoubleMu0er2p0_SQ_OS_dEta_Max1p6 OR L1_DoubleMu0er2p0_SQ_OS_dEta_Max1p5 OR L1_DoubleMu0er1p5_SQ_OS_dR_Max1p4 OR L1_DoubleMu0er1p4_SQ_OS_dR_Max1p4 OR L1_TripleMu_5SQ_3SQ_0_DoubleMu_5_3_SQ_OS_Mass_Max9 OR L1_TripleMu_5SQ_3SQ_0OQ_DoubleMu_5_3_SQ_OS_Mass_Max9 OR L1_TripleMu_2SQ_1p5SQ_0OQ_Mass_Max12 OR L1_DoubleMu4_SQ_OS_dR_Max1p2 OR L1_DoubleMu4p5_SQ_OS_dR_Max1p2',
+
+          # BTV
+          'hltL1sDiJet16er2p5Mu3dRMax0p4': 'L1_Mu3_Jet16er2p5_dR_Max0p4',
+          'hltL1sDiJet35er2p5Mu3dRMax0p4': 'L1_Mu3_Jet35er2p5_dR_Max0p4',
+          'hltL1sDiJet60er2p5Mu3dRMax0p4': 'L1_Mu3_Jet60er2p5_dR_Max0p4',
+          'hltL1sDiJet80er2p5Mu3dRMax0p4': 'L1_Mu3_Jet80er2p5_dR_Max0p4',
+          'hltL1sDiJet120er2p5Mu3dRMax0p8': 'L1_Mu3_Jet120er2p5_dR_Max0p8',
+
+          # JME
+          'hltL1sSingleJet35Fwd': 'L1_SingleJet35_FWD3p0',
+          'hltL1sSingleJet35OrZeroBias': 'L1_SingleJet35 OR L1_SingleJet35_FWD3p0 OR L1_ZeroBias',
+          'hltL1sSingleJet60Fwd': 'L1_SingleJet60_FWD3p0',
+          'hltL1sSingleJet60Or60Fwd': 'L1_SingleJet60 OR L1_SingleJet60_FWD3p0',
+          'hltL1sSingleJet90Fwd': 'L1_SingleJet90_FWD3p0',
+          'hltL1sV0SingleJet60Or60Fwd': 'L1_SingleJet60 OR L1_SingleJet60_FWD3p0 OR L1_SingleJet90 OR L1_SingleJet90_FWD3p0',
+          'hltL1sSingleJet120Fwd': 'L1_SingleJet120_FWD3p0',
+          'hltL1sSingleJet120Or120Fwd': 'L1_SingleJet120 OR L1_SingleJet120_FWD3p0',
+
+          # HIG (VBF HTauTau)
+          'hltL1VBFDiJetIsoTau': 'L1_DoubleJet35_Mass_Min450_IsoTau45er2p1_RmOvlp_dR0p5',
+
+          # BPH (BsMuMu)
+          'hltL1sDoubleMuForBs': 'L1_DoubleMu3er2p0_SQ_OS_dR_Max1p4 OR L1_DoubleMu0er2p0_SQ_OS_dEta_Max1p6 OR L1_DoubleMu0er1p4_OQ_OS_dEta_Max1p6 OR L1_DoubleMu0er2p0_SQ_OS_dEta_Max1p5 OR L1_DoubleMu0er1p4_SQ_OS_dR_Max1p4 OR L1_DoubleMu0er1p5_SQ_OS_dR_Max1p4 OR L1_DoubleMu4p5_SQ_OS_dR_Max1p2 OR L1_DoubleMu4_SQ_OS_dR_Max1p2',
+          'hltL1sDoubleMuForBsToMMG': 'L1_DoubleMu3er2p0_SQ_OS_dR_Max1p4 OR L1_DoubleMu0er2p0_SQ_OS_dEta_Max1p6 OR L1_DoubleMu0er2p0_SQ_OS_dEta_Max1p5 OR L1_DoubleMu0er1p4_SQ_OS_dR_Max1p4 OR L1_DoubleMu0er1p5_SQ_OS_dR_Max1p4 OR L1_DoubleMu4p5_SQ_OS_dR_Max1p2 OR L1_DoubleMu4_SQ_OS_dR_Max1p2',
+          'hltL1sDoubleMuForLowMassDisplaced': 'L1_DoubleMu3er2p0_SQ_OS_dR_Max1p4 OR L1_DoubleMu0er2p0_SQ_OS_dEta_Max1p6 OR L1_DoubleMu0er1p4_OQ_OS_dEta_Max1p6 OR L1_DoubleMu0er2p0_SQ_OS_dEta_Max1p5 OR L1_DoubleMu0er1p4_SQ_OS_dR_Max1p4 OR L1_DoubleMu0er1p5_SQ_OS_dR_Max1p4 OR L1_DoubleMu4p5_SQ_OS_dR_Max1p2 OR L1_DoubleMu4_SQ_OS_dR_Max1p2',
+          'hltL1sDoubleMuForLowMassInclusive': 'L1_DoubleMu3er2p0_SQ_OS_dR_Max1p4 OR L1_DoubleMu0er2p0_SQ_OS_dEta_Max1p6 OR L1_DoubleMu0er1p4_OQ_OS_dEta_Max1p6 OR L1_DoubleMu0er2p0_SQ_OS_dEta_Max1p5 OR L1_DoubleMu0er1p4_SQ_OS_dR_Max1p4 OR L1_DoubleMu0er1p5_SQ_OS_dR_Max1p4 OR L1_DoubleMu4p5_SQ_OS_dR_Max1p2 OR L1_DoubleMu4_SQ_OS_dR_Max1p2',
+
+          # SMP (W->3pi)
+          'hltL1sDoubleTauBigORWithLowMass': 'L1_DoubleIsoTau34er2p1 OR L1_DoubleIsoTau36er2p1 OR L1_DoubleTau70er2p1 OR L1_DoubleIsoTau28er2p1_Mass_Max80 OR L1_DoubleIsoTau30er2p1_Mass_Max80',
+        })
+
+    elif l1tMenu != '2023_v1_0_0':
+        raise RuntimeError(f'ERROR -- invalid value for argument "l1tMenu" (must be "2022_v1_4_0", or "2023_v1_0_0"): "{l1tMenu}"')
+
+    for modName,oldSeed in dictL1TSeeds.items():
         try: getattr(process, modName).L1SeedsLogicalExpression = oldSeed
         except: pass
 
     return process
+
+def customizeHLTFor2022L1TMenu(process):
+    return _updateL1TSeedModules(process, l1tMenu = '2022_v1_4_0')
+
+def customizeHLTFor2023L1TMenu_v1_0_0(process):
+    return _updateL1TSeedModules(process, l1tMenu = '2023_v1_0_0')


### PR DESCRIPTION
This PR adds a customisation function to make the latest GRun menu compatible with the first L1T menu of 2023, i.e. `2023-v1_0_0`. The customisation modifies the L1T-seed modules of the Parking-VBF triggers to use the existing "inclusive tight" L1T seed, instead of the VBF-exclusive seeds available only in the very latest L1T menu (e.g. `2023-v1_1_0`).

The customisation to make the GRun menu compatible with the 2022 L1T menu (`2022-v1_4_0`) is also updated accordingly.

@sanuvarghese , can you please have a look ?